### PR TITLE
Add new config option: disable cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
-#gulp-sass-import-json
+# gulp-sass-import-json
 
 Gulp plugin for sass
 
-##Install
+## Install
 ```bash
 npm i gulp-sass-import-json
 ```
 
-##Example
+## Configuration
+### sassImportJson([options])
+#### options.isSass
+Type: `Boolean`
+
+Set it to `true` if you want to have SCCS syntax. Otherwise it will be Sass syntax.
+
+Default value is `false`.
+
+#### options.cache
+Type: `Boolean`
+
+Cache the imported JSON files. Caching makes builds faster. If you have watch tasks and want to reload changes to the JSOn files, you have to use `false`.
+
+Default value is `true`.
+
+
+## Example
 //gulp-build.js
 ```js
 var sassImportJson = require('gulp-sass-import-json');

--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ module.exports = function (options) {
 
                 compiledJsonContent = jsonToSass(importJsonContent, options.isScss || false);
 
-                jsonCache[importJsonPath] = compiledJsonContent;
+                if (options.cache === true || options.cache === undefined) {
+                    jsonCache[importJsonPath] = compiledJsonContent;
+                }
                 return compiledJsonContent;
             });
 


### PR DESCRIPTION
## Problem
Due to caching, it is not possible to get the updated JSON file if it changes during a watch task.
See issue #2

## Solution
Added a config option `{ cache: false }` to disable the caching. Default behaviour is "enabled cache".
I also added documentation for the available options.

## Issue
#2